### PR TITLE
Add language server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/out
+/node_modules

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -3,7 +3,7 @@
 // Hover to view descriptions of existing attributes.
 // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
 {
-	"version": "0.2.0",
+    "version": "0.2.0",
     "configurations": [
         {
             "name": "Launch client",
@@ -13,22 +13,22 @@
             "args": [
                 "--extensionDevelopmentPath=${workspaceFolder}"
             ],
-			"stopOnEntry": false,
+            "stopOnEntry": false,
             "sourceMaps": true,
             "outFiles": [
                 "${workspaceFolder}/out/**/*.js"
             ]
         },
-		{
-			"name": "Attach to server",
-			"type": "node",
-			"request": "attach",
-			"port": 6009,
-			"sourceMaps": true,
-			"outFiles": [
-				"${workspaceRoot}/out/**/*.js"
+        {
+            "name": "Attach to server",
+            "type": "node",
+            "request": "attach",
+            "port": 6009,
+            "sourceMaps": true,
+            "outFiles": [
+                "${workspaceRoot}/out/**/*.js"
             ],
             "protocol": "inspector"
-		}
+        }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,13 +6,29 @@
 	"version": "0.2.0",
     "configurations": [
         {
-            "name": "Extension",
+            "name": "Launch client",
             "type": "extensionHost",
             "request": "launch",
             "runtimeExecutable": "${execPath}",
             "args": [
                 "--extensionDevelopmentPath=${workspaceFolder}"
+            ],
+			"stopOnEntry": false,
+            "sourceMaps": true,
+            "outFiles": [
+                "${workspaceFolder}/out/**/*.js"
             ]
-        }
+        },
+		{
+			"name": "Attach to server",
+			"type": "node",
+			"request": "attach",
+			"port": 6009,
+			"sourceMaps": true,
+			"outFiles": [
+				"${workspaceRoot}/out/**/*.js"
+            ],
+            "protocol": "inspector"
+		}
     ]
 }

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,3 +1,8 @@
 # This is ignored when publishing extension
 .vscode/**
-.vscode-test/**
+.gitignore
+
+# Don't publish source (TypeScript) files and corresponding map and configuration files
+src/**
+**/*.map
+tsconfig.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "javascript-ejs-support",
-	"version": "0.2.3",
+	"version": "0.3.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,2417 @@
+{
+	"name": "javascript-ejs-support",
+	"version": "0.2.3",
+	"lockfileVersion": 1,
+	"requires": true,
+	"dependencies": {
+		"@types/node": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.0.0.tgz",
+			"integrity": "sha512-kctoM36XiNZT86a7tPsUje+Q/yl+dqELjtYApi0T5eOQ90Elhu0MI10rmYk44yEP4v1jdDvtjQ9DFtpRtHf2Bw==",
+			"dev": true
+		},
+		"ajv": {
+			"version": "5.5.2",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+			"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+			"requires": {
+				"co": "^4.6.0",
+				"fast-deep-equal": "^1.0.0",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.3.0"
+			}
+		},
+		"ansi-cyan": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-cyan/-/ansi-cyan-0.1.1.tgz",
+			"integrity": "sha1-U4rlKK+JgvKK4w2G8vF0VtJgmHM=",
+			"requires": {
+				"ansi-wrap": "0.1.0"
+			}
+		},
+		"ansi-gray": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
+			"integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
+			"requires": {
+				"ansi-wrap": "0.1.0"
+			}
+		},
+		"ansi-red": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-red/-/ansi-red-0.1.1.tgz",
+			"integrity": "sha1-jGOPnRCAgAo1PJwoyKgcpHBdlGw=",
+			"requires": {
+				"ansi-wrap": "0.1.0"
+			}
+		},
+		"ansi-regex": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+		},
+		"ansi-styles": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+		},
+		"ansi-wrap": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+			"integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768="
+		},
+		"arr-diff": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz",
+			"integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
+			"requires": {
+				"arr-flatten": "^1.0.1",
+				"array-slice": "^0.2.3"
+			}
+		},
+		"arr-flatten": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+		},
+		"arr-union": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-2.1.0.tgz",
+			"integrity": "sha1-IPnqtexw9cfSFbEHexw5Fh0pLH0="
+		},
+		"array-differ": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+			"integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE="
+		},
+		"array-slice": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
+			"integrity": "sha1-3Tz7gO15c6dRF82sabC5nshhhvU="
+		},
+		"array-union": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+			"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+			"requires": {
+				"array-uniq": "^1.0.1"
+			}
+		},
+		"array-uniq": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
+		},
+		"array-unique": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+			"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+		},
+		"arrify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+		},
+		"asn1": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+			"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+		},
+		"assert-plus": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+			"integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
+		},
+		"asynckit": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+		},
+		"aws-sign2": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+			"integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
+		},
+		"aws4": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
+			"integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
+		},
+		"balanced-match": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+		},
+		"bcrypt-pbkdf": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+			"integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+			"optional": true,
+			"requires": {
+				"tweetnacl": "^0.14.3"
+			}
+		},
+		"beeper": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
+			"integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak="
+		},
+		"block-stream": {
+			"version": "0.0.9",
+			"resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+			"integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+			"requires": {
+				"inherits": "~2.0.0"
+			}
+		},
+		"boom": {
+			"version": "2.10.1",
+			"resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+			"integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+			"requires": {
+				"hoek": "2.x.x"
+			}
+		},
+		"brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"requires": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"braces": {
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+			"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+			"requires": {
+				"expand-range": "^1.8.1",
+				"preserve": "^0.2.0",
+				"repeat-element": "^1.1.2"
+			}
+		},
+		"browser-stdout": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+			"integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8="
+		},
+		"buffer-crc32": {
+			"version": "0.2.13",
+			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+			"integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
+		},
+		"buffer-from": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
+			"integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA=="
+		},
+		"caseless": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+			"integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c="
+		},
+		"chalk": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+			"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+			"requires": {
+				"ansi-styles": "^2.2.1",
+				"escape-string-regexp": "^1.0.2",
+				"has-ansi": "^2.0.0",
+				"strip-ansi": "^3.0.0",
+				"supports-color": "^2.0.0"
+			}
+		},
+		"clone": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+			"integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8="
+		},
+		"clone-buffer": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
+			"integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg="
+		},
+		"clone-stats": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+			"integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
+		},
+		"cloneable-readable": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.2.tgz",
+			"integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
+			"requires": {
+				"inherits": "^2.0.1",
+				"process-nextick-args": "^2.0.0",
+				"readable-stream": "^2.3.5"
+			}
+		},
+		"co": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+		},
+		"color-support": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+			"integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="
+		},
+		"combined-stream": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+			"integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+			"requires": {
+				"delayed-stream": "~1.0.0"
+			}
+		},
+		"commander": {
+			"version": "2.15.1",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+			"integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
+		},
+		"concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+		},
+		"convert-source-map": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+			"integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU="
+		},
+		"core-util-is": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+		},
+		"cryptiles": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+			"integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+			"requires": {
+				"boom": "2.x.x"
+			}
+		},
+		"dashdash": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+			"requires": {
+				"assert-plus": "^1.0.0"
+			},
+			"dependencies": {
+				"assert-plus": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+				}
+			}
+		},
+		"dateformat": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
+			"integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI="
+		},
+		"debug": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+			"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+			"requires": {
+				"ms": "2.0.0"
+			}
+		},
+		"deep-assign": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/deep-assign/-/deep-assign-1.0.0.tgz",
+			"integrity": "sha1-sJJ0O+hCfcYh6gBnzex+cN0Z83s=",
+			"requires": {
+				"is-obj": "^1.0.0"
+			}
+		},
+		"delayed-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+		},
+		"diff": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
+			"integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww=="
+		},
+		"duplexer": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
+		},
+		"duplexer2": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+			"integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
+			"requires": {
+				"readable-stream": "~1.1.9"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+				},
+				"readable-stream": {
+					"version": "1.1.14",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+					"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+					"requires": {
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.1",
+						"isarray": "0.0.1",
+						"string_decoder": "~0.10.x"
+					}
+				},
+				"string_decoder": {
+					"version": "0.10.31",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+				}
+			}
+		},
+		"duplexify": {
+			"version": "3.5.4",
+			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.4.tgz",
+			"integrity": "sha512-JzYSLYMhoVVBe8+mbHQ4KgpvHpm0DZpJuL8PY93Vyv1fW7jYJ90LoXa1di/CVbJM+TgMs91rbDapE/RNIfnJsA==",
+			"requires": {
+				"end-of-stream": "^1.0.0",
+				"inherits": "^2.0.1",
+				"readable-stream": "^2.0.0",
+				"stream-shift": "^1.0.0"
+			}
+		},
+		"ecc-jsbn": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+			"integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+			"optional": true,
+			"requires": {
+				"jsbn": "~0.1.0"
+			}
+		},
+		"end-of-stream": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+			"requires": {
+				"once": "^1.4.0"
+			}
+		},
+		"escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+		},
+		"event-stream": {
+			"version": "3.3.4",
+			"resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+			"integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
+			"requires": {
+				"duplexer": "~0.1.1",
+				"from": "~0",
+				"map-stream": "~0.1.0",
+				"pause-stream": "0.0.11",
+				"split": "0.3",
+				"stream-combiner": "~0.0.4",
+				"through": "~2.3.1"
+			}
+		},
+		"expand-brackets": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+			"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+			"requires": {
+				"is-posix-bracket": "^0.1.0"
+			}
+		},
+		"expand-range": {
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+			"requires": {
+				"fill-range": "^2.1.0"
+			}
+		},
+		"extend": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+			"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+		},
+		"extend-shallow": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
+			"integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
+			"requires": {
+				"kind-of": "^1.1.0"
+			}
+		},
+		"extglob": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+			"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+			"requires": {
+				"is-extglob": "^1.0.0"
+			},
+			"dependencies": {
+				"is-extglob": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+				}
+			}
+		},
+		"extsprintf": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+		},
+		"fancy-log": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.2.tgz",
+			"integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
+			"requires": {
+				"ansi-gray": "^0.1.1",
+				"color-support": "^1.1.3",
+				"time-stamp": "^1.0.0"
+			}
+		},
+		"fast-deep-equal": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+			"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+		},
+		"fast-json-stable-stringify": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+		},
+		"fd-slicer": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
+			"integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+			"requires": {
+				"pend": "~1.2.0"
+			}
+		},
+		"filename-regex": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
+		},
+		"fill-range": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+			"integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+			"requires": {
+				"is-number": "^2.1.0",
+				"isobject": "^2.0.0",
+				"randomatic": "^1.1.3",
+				"repeat-element": "^1.1.2",
+				"repeat-string": "^1.5.2"
+			}
+		},
+		"first-chunk-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
+			"integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04="
+		},
+		"for-in": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+		},
+		"for-own": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+			"requires": {
+				"for-in": "^1.0.1"
+			}
+		},
+		"forever-agent": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+		},
+		"form-data": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+			"integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+			"requires": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.5",
+				"mime-types": "^2.1.12"
+			}
+		},
+		"from": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+			"integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4="
+		},
+		"fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+		},
+		"fstream": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+			"integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+			"requires": {
+				"graceful-fs": "^4.1.2",
+				"inherits": "~2.0.0",
+				"mkdirp": ">=0.5 0",
+				"rimraf": "2"
+			}
+		},
+		"generate-function": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+			"integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ="
+		},
+		"generate-object-property": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+			"integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+			"requires": {
+				"is-property": "^1.0.0"
+			}
+		},
+		"getpass": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+			"requires": {
+				"assert-plus": "^1.0.0"
+			},
+			"dependencies": {
+				"assert-plus": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+				}
+			}
+		},
+		"glob": {
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+			"requires": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			}
+		},
+		"glob-base": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+			"requires": {
+				"glob-parent": "^2.0.0",
+				"is-glob": "^2.0.0"
+			},
+			"dependencies": {
+				"glob-parent": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+					"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+					"requires": {
+						"is-glob": "^2.0.0"
+					}
+				},
+				"is-extglob": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+				},
+				"is-glob": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"requires": {
+						"is-extglob": "^1.0.0"
+					}
+				}
+			}
+		},
+		"glob-parent": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+			"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+			"requires": {
+				"is-glob": "^3.1.0",
+				"path-dirname": "^1.0.0"
+			}
+		},
+		"glob-stream": {
+			"version": "5.3.5",
+			"resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
+			"integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
+			"requires": {
+				"extend": "^3.0.0",
+				"glob": "^5.0.3",
+				"glob-parent": "^3.0.0",
+				"micromatch": "^2.3.7",
+				"ordered-read-streams": "^0.3.0",
+				"through2": "^0.6.0",
+				"to-absolute-glob": "^0.1.1",
+				"unique-stream": "^2.0.2"
+			},
+			"dependencies": {
+				"glob": {
+					"version": "5.0.15",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+					"integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+					"requires": {
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "2 || 3",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
+				"isarray": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+				},
+				"readable-stream": {
+					"version": "1.0.34",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+					"requires": {
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.1",
+						"isarray": "0.0.1",
+						"string_decoder": "~0.10.x"
+					}
+				},
+				"string_decoder": {
+					"version": "0.10.31",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+				},
+				"through2": {
+					"version": "0.6.5",
+					"resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+					"integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+					"requires": {
+						"readable-stream": ">=1.0.33-1 <1.1.0-0",
+						"xtend": ">=4.0.0 <4.1.0-0"
+					}
+				}
+			}
+		},
+		"glogg": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.1.tgz",
+			"integrity": "sha512-ynYqXLoluBKf9XGR1gA59yEJisIL7YHEH4xr3ZziHB5/yl4qWfaK8Js9jGe6gBGCSCKVqiyO30WnRZADvemUNw==",
+			"requires": {
+				"sparkles": "^1.0.0"
+			}
+		},
+		"graceful-fs": {
+			"version": "4.1.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+		},
+		"growl": {
+			"version": "1.10.3",
+			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+			"integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q=="
+		},
+		"gulp-chmod": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/gulp-chmod/-/gulp-chmod-2.0.0.tgz",
+			"integrity": "sha1-AMOQuSigeZslGsz2MaoJ4BzGKZw=",
+			"requires": {
+				"deep-assign": "^1.0.0",
+				"stat-mode": "^0.2.0",
+				"through2": "^2.0.0"
+			}
+		},
+		"gulp-filter": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/gulp-filter/-/gulp-filter-5.1.0.tgz",
+			"integrity": "sha1-oF4Rr/sHz33PQafeHLe2OsN4PnM=",
+			"requires": {
+				"multimatch": "^2.0.0",
+				"plugin-error": "^0.1.2",
+				"streamfilter": "^1.0.5"
+			}
+		},
+		"gulp-gunzip": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/gulp-gunzip/-/gulp-gunzip-1.0.0.tgz",
+			"integrity": "sha1-FbdBFF6Dqcb1CIYkG1fMWHHxUak=",
+			"requires": {
+				"through2": "~0.6.5",
+				"vinyl": "~0.4.6"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+				},
+				"readable-stream": {
+					"version": "1.0.34",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+					"requires": {
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.1",
+						"isarray": "0.0.1",
+						"string_decoder": "~0.10.x"
+					}
+				},
+				"string_decoder": {
+					"version": "0.10.31",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+				},
+				"through2": {
+					"version": "0.6.5",
+					"resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+					"integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+					"requires": {
+						"readable-stream": ">=1.0.33-1 <1.1.0-0",
+						"xtend": ">=4.0.0 <4.1.0-0"
+					}
+				}
+			}
+		},
+		"gulp-remote-src": {
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/gulp-remote-src/-/gulp-remote-src-0.4.3.tgz",
+			"integrity": "sha1-VyjP1kNDPdSEXd7wlp8PlxoqtKE=",
+			"requires": {
+				"event-stream": "~3.3.4",
+				"node.extend": "~1.1.2",
+				"request": "~2.79.0",
+				"through2": "~2.0.3",
+				"vinyl": "~2.0.1"
+			},
+			"dependencies": {
+				"clone": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+					"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
+				},
+				"clone-stats": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+					"integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA="
+				},
+				"request": {
+					"version": "2.79.0",
+					"resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
+					"integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
+					"requires": {
+						"aws-sign2": "~0.6.0",
+						"aws4": "^1.2.1",
+						"caseless": "~0.11.0",
+						"combined-stream": "~1.0.5",
+						"extend": "~3.0.0",
+						"forever-agent": "~0.6.1",
+						"form-data": "~2.1.1",
+						"har-validator": "~2.0.6",
+						"hawk": "~3.1.3",
+						"http-signature": "~1.1.0",
+						"is-typedarray": "~1.0.0",
+						"isstream": "~0.1.2",
+						"json-stringify-safe": "~5.0.1",
+						"mime-types": "~2.1.7",
+						"oauth-sign": "~0.8.1",
+						"qs": "~6.3.0",
+						"stringstream": "~0.0.4",
+						"tough-cookie": "~2.3.0",
+						"tunnel-agent": "~0.4.1",
+						"uuid": "^3.0.0"
+					}
+				},
+				"vinyl": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.0.2.tgz",
+					"integrity": "sha1-CjcT2NTpIhxY8QyhbAEWyeJe2nw=",
+					"requires": {
+						"clone": "^1.0.0",
+						"clone-buffer": "^1.0.0",
+						"clone-stats": "^1.0.0",
+						"cloneable-readable": "^1.0.0",
+						"is-stream": "^1.1.0",
+						"remove-trailing-separator": "^1.0.1",
+						"replace-ext": "^1.0.0"
+					}
+				}
+			}
+		},
+		"gulp-sourcemaps": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
+			"integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
+			"requires": {
+				"convert-source-map": "^1.1.1",
+				"graceful-fs": "^4.1.2",
+				"strip-bom": "^2.0.0",
+				"through2": "^2.0.0",
+				"vinyl": "^1.0.0"
+			},
+			"dependencies": {
+				"clone": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+					"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
+				},
+				"replace-ext": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+					"integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
+				},
+				"vinyl": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+					"integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
+					"requires": {
+						"clone": "^1.0.0",
+						"clone-stats": "^0.0.1",
+						"replace-ext": "0.0.1"
+					}
+				}
+			}
+		},
+		"gulp-symdest": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/gulp-symdest/-/gulp-symdest-1.1.0.tgz",
+			"integrity": "sha1-wWUyBzLRks5W/ZQnH/oSMjS/KuA=",
+			"requires": {
+				"event-stream": "^3.3.1",
+				"mkdirp": "^0.5.1",
+				"queue": "^3.1.0",
+				"vinyl-fs": "^2.4.3"
+			}
+		},
+		"gulp-untar": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/gulp-untar/-/gulp-untar-0.0.6.tgz",
+			"integrity": "sha1-1r3v3n6ajgVMnxYjhaB4LEvnQAA=",
+			"requires": {
+				"event-stream": "~3.3.4",
+				"gulp-util": "~3.0.8",
+				"streamifier": "~0.1.1",
+				"tar": "^2.2.1",
+				"through2": "~2.0.3"
+			}
+		},
+		"gulp-util": {
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+			"integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
+			"requires": {
+				"array-differ": "^1.0.0",
+				"array-uniq": "^1.0.2",
+				"beeper": "^1.0.0",
+				"chalk": "^1.0.0",
+				"dateformat": "^2.0.0",
+				"fancy-log": "^1.1.0",
+				"gulplog": "^1.0.0",
+				"has-gulplog": "^0.1.0",
+				"lodash._reescape": "^3.0.0",
+				"lodash._reevaluate": "^3.0.0",
+				"lodash._reinterpolate": "^3.0.0",
+				"lodash.template": "^3.0.0",
+				"minimist": "^1.1.0",
+				"multipipe": "^0.1.2",
+				"object-assign": "^3.0.0",
+				"replace-ext": "0.0.1",
+				"through2": "^2.0.0",
+				"vinyl": "^0.5.0"
+			},
+			"dependencies": {
+				"clone": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+					"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
+				},
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+				},
+				"object-assign": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+					"integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
+				},
+				"replace-ext": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+					"integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
+				},
+				"vinyl": {
+					"version": "0.5.3",
+					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
+					"integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
+					"requires": {
+						"clone": "^1.0.0",
+						"clone-stats": "^0.0.1",
+						"replace-ext": "0.0.1"
+					}
+				}
+			}
+		},
+		"gulp-vinyl-zip": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/gulp-vinyl-zip/-/gulp-vinyl-zip-2.1.0.tgz",
+			"integrity": "sha1-JOQGhdwFtxSZlSRQmeBZAmO+ja0=",
+			"requires": {
+				"event-stream": "^3.3.1",
+				"queue": "^4.2.1",
+				"through2": "^2.0.3",
+				"vinyl": "^2.0.2",
+				"vinyl-fs": "^2.0.0",
+				"yauzl": "^2.2.1",
+				"yazl": "^2.2.1"
+			},
+			"dependencies": {
+				"clone": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
+					"integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs="
+				},
+				"clone-stats": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+					"integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA="
+				},
+				"queue": {
+					"version": "4.4.2",
+					"resolved": "https://registry.npmjs.org/queue/-/queue-4.4.2.tgz",
+					"integrity": "sha512-fSMRXbwhMwipcDZ08enW2vl+YDmAmhcNcr43sCJL8DIg+CFOsoRLG23ctxA+fwNk1w55SePSiS7oqQQSgQoVJQ==",
+					"requires": {
+						"inherits": "~2.0.0"
+					}
+				},
+				"vinyl": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.1.0.tgz",
+					"integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
+					"requires": {
+						"clone": "^2.1.1",
+						"clone-buffer": "^1.0.0",
+						"clone-stats": "^1.0.0",
+						"cloneable-readable": "^1.0.0",
+						"remove-trailing-separator": "^1.0.1",
+						"replace-ext": "^1.0.0"
+					}
+				}
+			}
+		},
+		"gulplog": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
+			"integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
+			"requires": {
+				"glogg": "^1.0.0"
+			}
+		},
+		"har-schema": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+		},
+		"har-validator": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+			"integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+			"requires": {
+				"chalk": "^1.1.1",
+				"commander": "^2.9.0",
+				"is-my-json-valid": "^2.12.4",
+				"pinkie-promise": "^2.0.0"
+			}
+		},
+		"has-ansi": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+			"requires": {
+				"ansi-regex": "^2.0.0"
+			}
+		},
+		"has-flag": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+			"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+		},
+		"has-gulplog": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
+			"integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
+			"requires": {
+				"sparkles": "^1.0.0"
+			}
+		},
+		"hawk": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+			"integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+			"requires": {
+				"boom": "2.x.x",
+				"cryptiles": "2.x.x",
+				"hoek": "2.x.x",
+				"sntp": "1.x.x"
+			}
+		},
+		"he": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+			"integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
+		},
+		"hoek": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+			"integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+		},
+		"http-signature": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+			"integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+			"requires": {
+				"assert-plus": "^0.2.0",
+				"jsprim": "^1.2.2",
+				"sshpk": "^1.7.0"
+			}
+		},
+		"inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"requires": {
+				"once": "^1.3.0",
+				"wrappy": "1"
+			}
+		},
+		"inherits": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+		},
+		"is": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/is/-/is-3.2.1.tgz",
+			"integrity": "sha1-0Kwq1V63sL7JJqUmb2xmKqqD3KU="
+		},
+		"is-buffer": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+		},
+		"is-dotfile": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
+		},
+		"is-equal-shallow": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+			"requires": {
+				"is-primitive": "^2.0.0"
+			}
+		},
+		"is-extendable": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+		},
+		"is-extglob": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+		},
+		"is-glob": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+			"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+			"requires": {
+				"is-extglob": "^2.1.0"
+			}
+		},
+		"is-my-ip-valid": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
+			"integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ=="
+		},
+		"is-my-json-valid": {
+			"version": "2.17.2",
+			"resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.2.tgz",
+			"integrity": "sha512-IBhBslgngMQN8DDSppmgDv7RNrlFotuuDsKcrCP3+HbFaVivIBU7u9oiiErw8sH4ynx3+gOGQ3q2otkgiSi6kg==",
+			"requires": {
+				"generate-function": "^2.0.0",
+				"generate-object-property": "^1.1.0",
+				"is-my-ip-valid": "^1.0.0",
+				"jsonpointer": "^4.0.0",
+				"xtend": "^4.0.0"
+			}
+		},
+		"is-number": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+			"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+			"requires": {
+				"kind-of": "^3.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
+		},
+		"is-obj": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
+		},
+		"is-posix-bracket": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
+		},
+		"is-primitive": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
+		},
+		"is-property": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+			"integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
+		},
+		"is-stream": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+		},
+		"is-typedarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+		},
+		"is-utf8": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+		},
+		"is-valid-glob": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
+			"integrity": "sha1-1LVcafUYhvm2XHDWwmItN+KfSP4="
+		},
+		"isarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+		},
+		"isobject": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+			"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+			"requires": {
+				"isarray": "1.0.0"
+			}
+		},
+		"isstream": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+		},
+		"jsbn": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+			"optional": true
+		},
+		"json-schema": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+		},
+		"json-schema-traverse": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+		},
+		"json-stable-stringify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+			"requires": {
+				"jsonify": "~0.0.0"
+			}
+		},
+		"json-stringify-safe": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+		},
+		"jsonify": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+		},
+		"jsonpointer": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+			"integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk="
+		},
+		"jsprim": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+			"requires": {
+				"assert-plus": "1.0.0",
+				"extsprintf": "1.3.0",
+				"json-schema": "0.2.3",
+				"verror": "1.10.0"
+			},
+			"dependencies": {
+				"assert-plus": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+				}
+			}
+		},
+		"kind-of": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+			"integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ="
+		},
+		"lazystream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
+			"integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
+			"requires": {
+				"readable-stream": "^2.0.5"
+			}
+		},
+		"lodash._basecopy": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+			"integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY="
+		},
+		"lodash._basetostring": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+			"integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U="
+		},
+		"lodash._basevalues": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
+			"integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc="
+		},
+		"lodash._getnative": {
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+			"integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
+		},
+		"lodash._isiterateecall": {
+			"version": "3.0.9",
+			"resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+			"integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw="
+		},
+		"lodash._reescape": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
+			"integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo="
+		},
+		"lodash._reevaluate": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
+			"integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0="
+		},
+		"lodash._reinterpolate": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+			"integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
+		},
+		"lodash._root": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+			"integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI="
+		},
+		"lodash.escape": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
+			"integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
+			"requires": {
+				"lodash._root": "^3.0.0"
+			}
+		},
+		"lodash.isarguments": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+			"integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
+		},
+		"lodash.isarray": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+			"integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
+		},
+		"lodash.isequal": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+			"integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+		},
+		"lodash.keys": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+			"integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+			"requires": {
+				"lodash._getnative": "^3.0.0",
+				"lodash.isarguments": "^3.0.0",
+				"lodash.isarray": "^3.0.0"
+			}
+		},
+		"lodash.restparam": {
+			"version": "3.6.1",
+			"resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+			"integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
+		},
+		"lodash.template": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+			"integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
+			"requires": {
+				"lodash._basecopy": "^3.0.0",
+				"lodash._basetostring": "^3.0.0",
+				"lodash._basevalues": "^3.0.0",
+				"lodash._isiterateecall": "^3.0.0",
+				"lodash._reinterpolate": "^3.0.0",
+				"lodash.escape": "^3.0.0",
+				"lodash.keys": "^3.0.0",
+				"lodash.restparam": "^3.0.0",
+				"lodash.templatesettings": "^3.0.0"
+			}
+		},
+		"lodash.templatesettings": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
+			"integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
+			"requires": {
+				"lodash._reinterpolate": "^3.0.0",
+				"lodash.escape": "^3.0.0"
+			}
+		},
+		"map-stream": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+			"integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ="
+		},
+		"merge-stream": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+			"integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
+			"requires": {
+				"readable-stream": "^2.0.1"
+			}
+		},
+		"micromatch": {
+			"version": "2.3.11",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+			"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+			"requires": {
+				"arr-diff": "^2.0.0",
+				"array-unique": "^0.2.1",
+				"braces": "^1.8.2",
+				"expand-brackets": "^0.1.4",
+				"extglob": "^0.3.1",
+				"filename-regex": "^2.0.0",
+				"is-extglob": "^1.0.0",
+				"is-glob": "^2.0.1",
+				"kind-of": "^3.0.2",
+				"normalize-path": "^2.0.1",
+				"object.omit": "^2.0.0",
+				"parse-glob": "^3.0.4",
+				"regex-cache": "^0.4.2"
+			},
+			"dependencies": {
+				"arr-diff": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+					"requires": {
+						"arr-flatten": "^1.0.1"
+					}
+				},
+				"is-extglob": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+				},
+				"is-glob": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"requires": {
+						"is-extglob": "^1.0.0"
+					}
+				},
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
+		},
+		"mime-db": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+			"integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
+		},
+		"mime-types": {
+			"version": "2.1.18",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+			"integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+			"requires": {
+				"mime-db": "~1.33.0"
+			}
+		},
+		"minimatch": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"requires": {
+				"brace-expansion": "^1.1.7"
+			}
+		},
+		"minimist": {
+			"version": "0.0.8",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+		},
+		"mkdirp": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+			"requires": {
+				"minimist": "0.0.8"
+			}
+		},
+		"mocha": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
+			"integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
+			"requires": {
+				"browser-stdout": "1.3.0",
+				"commander": "2.11.0",
+				"debug": "3.1.0",
+				"diff": "3.3.1",
+				"escape-string-regexp": "1.0.5",
+				"glob": "7.1.2",
+				"growl": "1.10.3",
+				"he": "1.1.1",
+				"mkdirp": "0.5.1",
+				"supports-color": "4.4.0"
+			},
+			"dependencies": {
+				"commander": {
+					"version": "2.11.0",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+					"integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+				},
+				"supports-color": {
+					"version": "4.4.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+					"integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+					"requires": {
+						"has-flag": "^2.0.0"
+					}
+				}
+			}
+		},
+		"ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+		},
+		"multimatch": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
+			"integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
+			"requires": {
+				"array-differ": "^1.0.0",
+				"array-union": "^1.0.1",
+				"arrify": "^1.0.0",
+				"minimatch": "^3.0.0"
+			}
+		},
+		"multipipe": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+			"integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
+			"requires": {
+				"duplexer2": "0.0.2"
+			}
+		},
+		"node.extend": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/node.extend/-/node.extend-1.1.6.tgz",
+			"integrity": "sha1-p7iCyC1sk6SGOlUEvV3o7IYli5Y=",
+			"requires": {
+				"is": "^3.1.0"
+			}
+		},
+		"normalize-path": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+			"requires": {
+				"remove-trailing-separator": "^1.0.1"
+			}
+		},
+		"oauth-sign": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+			"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+		},
+		"object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+		},
+		"object.omit": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+			"requires": {
+				"for-own": "^0.1.4",
+				"is-extendable": "^0.1.1"
+			}
+		},
+		"once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"requires": {
+				"wrappy": "1"
+			}
+		},
+		"ordered-read-streams": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
+			"integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
+			"requires": {
+				"is-stream": "^1.0.1",
+				"readable-stream": "^2.0.1"
+			}
+		},
+		"parse-glob": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+			"requires": {
+				"glob-base": "^0.3.0",
+				"is-dotfile": "^1.0.0",
+				"is-extglob": "^1.0.0",
+				"is-glob": "^2.0.0"
+			},
+			"dependencies": {
+				"is-extglob": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+				},
+				"is-glob": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"requires": {
+						"is-extglob": "^1.0.0"
+					}
+				}
+			}
+		},
+		"path-dirname": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+			"integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA="
+		},
+		"path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+		},
+		"pause-stream": {
+			"version": "0.0.11",
+			"resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+			"integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+			"requires": {
+				"through": "~2.3"
+			}
+		},
+		"pend": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+			"integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
+		},
+		"performance-now": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+		},
+		"pinkie": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+		},
+		"pinkie-promise": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+			"requires": {
+				"pinkie": "^2.0.0"
+			}
+		},
+		"plugin-error": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-0.1.2.tgz",
+			"integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
+			"requires": {
+				"ansi-cyan": "^0.1.1",
+				"ansi-red": "^0.1.1",
+				"arr-diff": "^1.0.1",
+				"arr-union": "^2.0.1",
+				"extend-shallow": "^1.1.2"
+			}
+		},
+		"preserve": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
+		},
+		"process-nextick-args": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+		},
+		"punycode": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+			"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+		},
+		"qs": {
+			"version": "6.3.2",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
+			"integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw="
+		},
+		"querystringify": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.0.0.tgz",
+			"integrity": "sha512-eTPo5t/4bgaMNZxyjWx6N2a6AuE0mq51KWvpc7nU/MAqixcI6v6KrGUKES0HaomdnolQBBXU/++X6/QQ9KL4tw=="
+		},
+		"queue": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/queue/-/queue-3.1.0.tgz",
+			"integrity": "sha1-bEnQHwCeIlZ4h4nyv/rGuLmZBYU=",
+			"requires": {
+				"inherits": "~2.0.0"
+			}
+		},
+		"randomatic": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+			"integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+			"requires": {
+				"is-number": "^3.0.0",
+				"kind-of": "^4.0.0"
+			},
+			"dependencies": {
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"requires": {
+						"kind-of": "^3.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"kind-of": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
+		},
+		"readable-stream": {
+			"version": "2.3.6",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+			"requires": {
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
+			}
+		},
+		"regex-cache": {
+			"version": "0.4.4",
+			"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+			"requires": {
+				"is-equal-shallow": "^0.1.3"
+			}
+		},
+		"remove-trailing-separator": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+		},
+		"repeat-element": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+			"integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
+		},
+		"repeat-string": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+		},
+		"replace-ext": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+			"integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
+		},
+		"request": {
+			"version": "2.85.0",
+			"resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
+			"integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
+			"requires": {
+				"aws-sign2": "~0.7.0",
+				"aws4": "^1.6.0",
+				"caseless": "~0.12.0",
+				"combined-stream": "~1.0.5",
+				"extend": "~3.0.1",
+				"forever-agent": "~0.6.1",
+				"form-data": "~2.3.1",
+				"har-validator": "~5.0.3",
+				"hawk": "~6.0.2",
+				"http-signature": "~1.2.0",
+				"is-typedarray": "~1.0.0",
+				"isstream": "~0.1.2",
+				"json-stringify-safe": "~5.0.1",
+				"mime-types": "~2.1.17",
+				"oauth-sign": "~0.8.2",
+				"performance-now": "^2.1.0",
+				"qs": "~6.5.1",
+				"safe-buffer": "^5.1.1",
+				"stringstream": "~0.0.5",
+				"tough-cookie": "~2.3.3",
+				"tunnel-agent": "^0.6.0",
+				"uuid": "^3.1.0"
+			},
+			"dependencies": {
+				"assert-plus": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+				},
+				"aws-sign2": {
+					"version": "0.7.0",
+					"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+					"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+				},
+				"boom": {
+					"version": "4.3.1",
+					"resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+					"integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+					"requires": {
+						"hoek": "4.x.x"
+					}
+				},
+				"caseless": {
+					"version": "0.12.0",
+					"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+					"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+				},
+				"cryptiles": {
+					"version": "3.1.2",
+					"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+					"integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+					"requires": {
+						"boom": "5.x.x"
+					},
+					"dependencies": {
+						"boom": {
+							"version": "5.2.0",
+							"resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+							"integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+							"requires": {
+								"hoek": "4.x.x"
+							}
+						}
+					}
+				},
+				"form-data": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+					"integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+					"requires": {
+						"asynckit": "^0.4.0",
+						"combined-stream": "1.0.6",
+						"mime-types": "^2.1.12"
+					}
+				},
+				"har-validator": {
+					"version": "5.0.3",
+					"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+					"integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+					"requires": {
+						"ajv": "^5.1.0",
+						"har-schema": "^2.0.0"
+					}
+				},
+				"hawk": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+					"integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+					"requires": {
+						"boom": "4.x.x",
+						"cryptiles": "3.x.x",
+						"hoek": "4.x.x",
+						"sntp": "2.x.x"
+					}
+				},
+				"hoek": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+					"integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
+				},
+				"http-signature": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+					"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+					"requires": {
+						"assert-plus": "^1.0.0",
+						"jsprim": "^1.2.2",
+						"sshpk": "^1.7.0"
+					}
+				},
+				"qs": {
+					"version": "6.5.1",
+					"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+					"integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+				},
+				"sntp": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+					"integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+					"requires": {
+						"hoek": "4.x.x"
+					}
+				},
+				"tunnel-agent": {
+					"version": "0.6.0",
+					"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+					"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+					"requires": {
+						"safe-buffer": "^5.0.1"
+					}
+				}
+			}
+		},
+		"requires-port": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+			"integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+		},
+		"rimraf": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+			"requires": {
+				"glob": "^7.0.5"
+			}
+		},
+		"safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+		},
+		"semver": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+			"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+		},
+		"sntp": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+			"integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+			"requires": {
+				"hoek": "2.x.x"
+			}
+		},
+		"source-map": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+		},
+		"source-map-support": {
+			"version": "0.5.5",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.5.tgz",
+			"integrity": "sha512-mR7/Nd5l1z6g99010shcXJiNEaf3fEtmLhRB/sBcQVJGodcHCULPp2y4Sfa43Kv2zq7T+Izmfp/WHCR6dYkQCA==",
+			"requires": {
+				"buffer-from": "^1.0.0",
+				"source-map": "^0.6.0"
+			}
+		},
+		"sparkles": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
+			"integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM="
+		},
+		"split": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+			"integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+			"requires": {
+				"through": "2"
+			}
+		},
+		"sshpk": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
+			"integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
+			"requires": {
+				"asn1": "~0.2.3",
+				"assert-plus": "^1.0.0",
+				"bcrypt-pbkdf": "^1.0.0",
+				"dashdash": "^1.12.0",
+				"ecc-jsbn": "~0.1.1",
+				"getpass": "^0.1.1",
+				"jsbn": "~0.1.0",
+				"tweetnacl": "~0.14.0"
+			},
+			"dependencies": {
+				"assert-plus": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+				}
+			}
+		},
+		"stat-mode": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-0.2.2.tgz",
+			"integrity": "sha1-5sgLYjEj19gM8TLOU480YokHJQI="
+		},
+		"stream-combiner": {
+			"version": "0.0.4",
+			"resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+			"integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
+			"requires": {
+				"duplexer": "~0.1.1"
+			}
+		},
+		"stream-shift": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+			"integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
+		},
+		"streamfilter": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/streamfilter/-/streamfilter-1.0.7.tgz",
+			"integrity": "sha512-Gk6KZM+yNA1JpW0KzlZIhjo3EaBJDkYfXtYSbOwNIQ7Zd6006E6+sCFlW1NDvFG/vnXhKmw6TJJgiEQg/8lXfQ==",
+			"requires": {
+				"readable-stream": "^2.0.2"
+			}
+		},
+		"streamifier": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/streamifier/-/streamifier-0.1.1.tgz",
+			"integrity": "sha1-l+mNj6TRBdYqJpHR3AfoINuN/E8="
+		},
+		"string_decoder": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"requires": {
+				"safe-buffer": "~5.1.0"
+			}
+		},
+		"stringstream": {
+			"version": "0.0.5",
+			"resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+			"integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+		},
+		"strip-ansi": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+			"requires": {
+				"ansi-regex": "^2.0.0"
+			}
+		},
+		"strip-bom": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+			"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+			"requires": {
+				"is-utf8": "^0.2.0"
+			}
+		},
+		"strip-bom-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
+			"integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
+			"requires": {
+				"first-chunk-stream": "^1.0.0",
+				"strip-bom": "^2.0.0"
+			}
+		},
+		"supports-color": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+		},
+		"tar": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+			"integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+			"requires": {
+				"block-stream": "*",
+				"fstream": "^1.0.2",
+				"inherits": "2"
+			}
+		},
+		"through": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+		},
+		"through2": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+			"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+			"requires": {
+				"readable-stream": "^2.1.5",
+				"xtend": "~4.0.1"
+			}
+		},
+		"through2-filter": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
+			"integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
+			"requires": {
+				"through2": "~2.0.0",
+				"xtend": "~4.0.0"
+			}
+		},
+		"time-stamp": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
+			"integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM="
+		},
+		"to-absolute-glob": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
+			"integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
+			"requires": {
+				"extend-shallow": "^2.0.1"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				}
+			}
+		},
+		"tough-cookie": {
+			"version": "2.3.4",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+			"integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+			"requires": {
+				"punycode": "^1.4.1"
+			}
+		},
+		"tunnel-agent": {
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+			"integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
+		},
+		"tweetnacl": {
+			"version": "0.14.5",
+			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+			"optional": true
+		},
+		"typescript": {
+			"version": "2.8.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-2.8.3.tgz",
+			"integrity": "sha512-K7g15Bb6Ra4lKf7Iq2l/I5/En+hLIHmxWZGq3D4DIRNFxMNV6j2SHSvDOqs2tGd4UvD/fJvrwopzQXjLrT7Itw==",
+			"dev": true
+		},
+		"unique-stream": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
+			"integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
+			"requires": {
+				"json-stable-stringify": "^1.0.0",
+				"through2-filter": "^2.0.0"
+			}
+		},
+		"url-parse": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.0.tgz",
+			"integrity": "sha512-ERuGxDiQ6Xw/agN4tuoCRbmwRuZP0cJ1lJxJubXr5Q/5cDa78+Dc4wfvtxzhzhkm5VvmW6Mf8EVj9SPGN4l8Lg==",
+			"requires": {
+				"querystringify": "^2.0.0",
+				"requires-port": "^1.0.0"
+			}
+		},
+		"util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+		},
+		"uuid": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+			"integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
+		},
+		"vali-date": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
+			"integrity": "sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY="
+		},
+		"verror": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+			"requires": {
+				"assert-plus": "^1.0.0",
+				"core-util-is": "1.0.2",
+				"extsprintf": "^1.2.0"
+			},
+			"dependencies": {
+				"assert-plus": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+				}
+			}
+		},
+		"vinyl": {
+			"version": "0.4.6",
+			"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+			"integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
+			"requires": {
+				"clone": "^0.2.0",
+				"clone-stats": "^0.0.1"
+			}
+		},
+		"vinyl-fs": {
+			"version": "2.4.4",
+			"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
+			"integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
+			"requires": {
+				"duplexify": "^3.2.0",
+				"glob-stream": "^5.3.2",
+				"graceful-fs": "^4.0.0",
+				"gulp-sourcemaps": "1.6.0",
+				"is-valid-glob": "^0.3.0",
+				"lazystream": "^1.0.0",
+				"lodash.isequal": "^4.0.0",
+				"merge-stream": "^1.0.0",
+				"mkdirp": "^0.5.0",
+				"object-assign": "^4.0.0",
+				"readable-stream": "^2.0.4",
+				"strip-bom": "^2.0.0",
+				"strip-bom-stream": "^1.0.0",
+				"through2": "^2.0.0",
+				"through2-filter": "^2.0.0",
+				"vali-date": "^1.0.0",
+				"vinyl": "^1.0.0"
+			},
+			"dependencies": {
+				"clone": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+					"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
+				},
+				"replace-ext": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+					"integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
+				},
+				"vinyl": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+					"integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
+					"requires": {
+						"clone": "^1.0.0",
+						"clone-stats": "^0.0.1",
+						"replace-ext": "0.0.1"
+					}
+				}
+			}
+		},
+		"vinyl-source-stream": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/vinyl-source-stream/-/vinyl-source-stream-1.1.2.tgz",
+			"integrity": "sha1-YrU6E1YQqJbpjKlr7jqH8Aio54A=",
+			"requires": {
+				"through2": "^2.0.3",
+				"vinyl": "^0.4.3"
+			}
+		},
+		"vscode": {
+			"version": "1.1.16",
+			"resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.16.tgz",
+			"integrity": "sha512-nNsfYANLqqNfa2+flHyrIrqSIumIoV7R+R9H3gn0SAzZL3RGPEy8db3EYjXKPW5NEfssj/HZhSMI3J3pMNmhPA==",
+			"requires": {
+				"glob": "^7.1.2",
+				"gulp-chmod": "^2.0.0",
+				"gulp-filter": "^5.0.1",
+				"gulp-gunzip": "1.0.0",
+				"gulp-remote-src": "^0.4.3",
+				"gulp-symdest": "^1.1.0",
+				"gulp-untar": "^0.0.6",
+				"gulp-vinyl-zip": "^2.1.0",
+				"mocha": "^4.0.1",
+				"request": "^2.83.0",
+				"semver": "^5.4.1",
+				"source-map-support": "^0.5.0",
+				"url-parse": "^1.1.9",
+				"vinyl-source-stream": "^1.1.0"
+			}
+		},
+		"vscode-jsonrpc": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-3.5.0.tgz",
+			"integrity": "sha1-hyOdnhZrLXNSJFuKgTWXgEwdY6o="
+		},
+		"vscode-languageclient": {
+			"version": "3.5.1",
+			"resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-3.5.1.tgz",
+			"integrity": "sha512-GTQ+hSq/o4c/y6GYmyP9XNrVoIu0NFZ67KltSkqN+tO0eUNDIlrVNX+3DJzzyLhSsrctuGzuYWm3t87mNAcBmQ==",
+			"requires": {
+				"vscode-languageserver-protocol": "3.5.1"
+			}
+		},
+		"vscode-languageserver": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-4.1.2.tgz",
+			"integrity": "sha512-3iej2tuMaI9yirPXF7/fVyIvBhSzbwZ3EWFRb8bP6lc3tGv9SJHDaJLNyQMgo9J8CNpXil6dWarpJvGSA60v/w==",
+			"requires": {
+				"vscode-languageserver-protocol": "^3.7.0",
+				"vscode-uri": "^1.0.1"
+			},
+			"dependencies": {
+				"vscode-jsonrpc": {
+					"version": "3.6.1",
+					"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-3.6.1.tgz",
+					"integrity": "sha512-+Eb+Dxf2kC2h079msx61hkblxAKE0S2j78+8QpnigLAO2aIIjkCwTIH34etBrU8E8VItRinec7YEwULx9at5bQ=="
+				},
+				"vscode-languageserver-protocol": {
+					"version": "3.7.1",
+					"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.7.1.tgz",
+					"integrity": "sha512-AKX9XQ49m/lpiDLZJBypFNc5eAXNlSecunYU5m4o5WIwGgW86TWnXVdziuFm47W2SdigDa/jVbxLPSNUeut9fQ==",
+					"requires": {
+						"vscode-jsonrpc": "^3.6.0",
+						"vscode-languageserver-types": "^3.7.0"
+					}
+				},
+				"vscode-languageserver-types": {
+					"version": "3.7.1",
+					"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.7.1.tgz",
+					"integrity": "sha512-ftGfU79AnnI3OHCG7kzCCN47jNI7BjECPAH2yhddtYTiQk0bnFbuFeQKvpXQcyNI3GsKEx5b6kSiBYshTiep6w=="
+				}
+			}
+		},
+		"vscode-languageserver-protocol": {
+			"version": "3.5.1",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.5.1.tgz",
+			"integrity": "sha512-1fPDIwsAv1difCV+8daOrJEGunClNJWqnUHq/ncWrjhitKWXgGmRCjlwZ3gDUTt54yRcvXz1PXJDaRNvNH6pYA==",
+			"requires": {
+				"vscode-jsonrpc": "3.5.0",
+				"vscode-languageserver-types": "3.5.0"
+			}
+		},
+		"vscode-languageserver-types": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.5.0.tgz",
+			"integrity": "sha1-5I15li8LjgLelV4/UkkI4rGcA3Q="
+		},
+		"vscode-uri": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.3.tgz",
+			"integrity": "sha1-Yxvb9xbcyrDmUpGo3CXCMjIIWlI="
+		},
+		"wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+		},
+		"xtend": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+		},
+		"yauzl": {
+			"version": "2.9.1",
+			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.9.1.tgz",
+			"integrity": "sha1-qBmB6nCleUYTOIPwKcWCGok1mn8=",
+			"requires": {
+				"buffer-crc32": "~0.2.3",
+				"fd-slicer": "~1.0.1"
+			}
+		},
+		"yazl": {
+			"version": "2.4.3",
+			"resolved": "https://registry.npmjs.org/yazl/-/yazl-2.4.3.tgz",
+			"integrity": "sha1-7CblzIfVYBud+EMtvdPNLlFzoHE=",
+			"requires": {
+				"buffer-crc32": "~0.2.3"
+			}
+		}
+	}
+}

--- a/package.json
+++ b/package.json
@@ -57,14 +57,26 @@
 		"configuration": {
 			"title": "EJS support configuration",
 			"properties": {
-				"javascript-ejs-support.maxNumberOfProblems": {
+				"ejs-support.enable": {
+					"scope": "resource",
+					"type": "boolean",
+					"default": true,
+					"description": "Enable or disable the EJS support extension (TODO: implement this functionality)"
+				},
+				"ejs-support.maxNumberOfProblems": {
 					"scope": "resource",
 					"type": "number",
 					"default": 100,
 					"description": "Maximum number of problems reported"
 				}
 			}
-		}
+		},
+		"commands": [
+			{
+				"command": "extension.sayHello",
+				"title": "Hello World"
+			}
+		]
 	},
 	"scripts": {
 		"vscode:prepublish": "tsc -p ./",

--- a/package.json
+++ b/package.json
@@ -2,15 +2,20 @@
 	"name": "javascript-ejs-support",
 	"displayName": "EJS language support",
 	"description": "2018 - EJS language support for Visual Studio Code.",
-	"version": "0.2.3",
+	"author": "Derek Thomas <Derek@digitalbrainstem.com>",
 	"license": "MIT",
+	"version": "0.2.3",
 	"publisher": "DigitalBrainstem",
-	"author": {
-		"name": "Derek Thomas",
-		"email": "Derek@digitalbrainstem.com"
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/Digitalbrainstem/ejs-grammar.git"
+	},
+	"bugs": {
+		"url": "https://github.com/Digitalbrainstem/ejs-grammar/issues",
+		"email": "help@digitalbrainstem.com"
 	},
 	"engines": {
-		"vscode": "^0.10.x"
+		"vscode": "^1.18.x"
 	},
 	"categories": [
 		"Languages"
@@ -20,37 +25,59 @@
 		"embedded javascript",
 		"syntax highlighting"
 	],
+	"activationEvents": [
+		"onLanguage:ejs"
+	],
+	"main": "./out/src/extension",
+	"contributes": {
+		"languages": [
+			{
+				"id": "ejs",
+				"extensions": [
+					".ejs",
+					".html.ejs"
+				],
+				"aliases": [
+					"Embedded Javascript",
+					"ejs"
+				],
+				"configuration": "./language-configuration.json"
+			}
+		],
+		"grammars": [
+			{
+				"language": "ejs",
+				"scopeName": "text.html.ejs",
+				"path": "./syntaxes/ejs.json",
+				"embeddedLanguages": {
+					"section.embedded.source.ejs": "ejs"
+				}
+			}
+		],
+		"configuration": {
+			"title": "EJS support configuration",
+			"properties": {
+				"javascript-ejs-support.maxNumberOfProblems": {
+					"scope": "resource",
+					"type": "number",
+					"default": 100,
+					"description": "Maximum number of problems reported"
+				}
+			}
+		}
+	},
 	"scripts": {
+		"vscode:prepublish": "tsc -p ./",
+		"postinstall": "node ./node_modules/vscode/bin/install",
 		"update-grammar": "node ../../build/npm/update-grammar.js grammars/ejs.json ./syntaxes/ejs.json"
 	},
-	"contributes": {
-		"languages": [{
-			"id": "ejs",
-			"extensions": [
-				".ejs",
-				".html.ejs"
-			],
-			"aliases": [
-				"Embedded Javascript",
-				"ejs"
-			],
-			"configuration": "./language-configuration.json"
-		}],
-		"grammars": [{
-			"language": "ejs",
-			"scopeName": "text.html.ejs",
-			"path": "./syntaxes/ejs.json",
-			"embeddedLanguages": {
-				"section.embedded.source.ejs": "ejs"
-			}
-		}]
+	"dependencies": {
+		"vscode": "^1.1.16",
+		"vscode-languageclient": "^3.5.0",
+		"vscode-languageserver": "^4.1.2"
 	},
-	"bugs": {
-		"url": "https://github.com/Digitalbrainstem/ejs-grammar/issues",
-		"email": "help@digitalbrainstem.com"
-	},
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/Digitalbrainstem/ejs-grammar.git"
+	"devDependencies": {
+		"@types/node": "^10.0.0",
+		"typescript": "^2.8.3"
 	}
 }

--- a/src/code-completion.ts
+++ b/src/code-completion.ts
@@ -1,0 +1,50 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) DigitalBrainstem
+ * Licensed under the MIT License. See LICENSE in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+'use strict';
+
+import { CompletionItem, CompletionItemKind } from 'vscode-languageserver';
+
+export class CodeCompletion {
+    static getCodeCompletions(): CompletionItem[] {
+        return COMPLETIONS;
+    }
+
+    static getItemResolveInfo(item: CompletionItem): CompletionItem {
+        for (let compl of COMPLETIONS) {
+            if (compl.data === item.data) {
+                item.detail = compl.detail || 'No documentation found.';
+                return item;
+            }
+        }
+
+        item.detail = item.detail || 'No documentation found.';
+        return item;
+    }
+}
+
+const COMPLETIONS: CompletionItem[] = [
+    {	// These are probably better used as snippets.
+        label: '<%',
+        kind: CompletionItemKind.Property,
+        commitCharacters: [' '],
+        data: 1,
+        detail: 'Scriptlet opening tag',
+        documentation: '\'Scriptlet\' tag, for control-flow, no output.'
+    },
+    {
+        label: '<%=',
+        kind: CompletionItemKind.Property,
+        commitCharacters: [' '],
+        data: 2,
+        detail: 'Scriptlet output opening tag',
+        documentation: 'Outputs the value into the template (HTML escaped)'
+    },
+    {
+        label: '<%_',
+        kind: CompletionItemKind.Property,
+        commitCharacters: [' '],
+        data: 3
+    }
+];

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,41 +6,48 @@
 
 import * as path from 'path';
 
-import { workspace, ExtensionContext } from 'vscode';
+import { workspace, commands, window, ExtensionContext } from 'vscode';
 import { LanguageClient, LanguageClientOptions, ServerOptions, TransportKind } from 'vscode-languageclient';
 
 export function activate(context: ExtensionContext) {
+	// Get path to server.js (using path.join for platform-specific delimiters, e.g. / or \)
+	const serverModule = context.asAbsolutePath(path.join('out', 'src', 'server.js'));
 
-	// The server is implemented in node
-	let serverModule = context.asAbsolutePath(path.join('out', 'src', 'server.js'));
+	// Server options used in debug mode
+	const debugOptions = { execArgv: ["--nolazy", "--inspect=6009"] };
 
-	// The debug options for the server
-	let debugOptions = { execArgv: ["--nolazy", "--inspect=6009"] };
-
-	// If the extension is launched in debug mode then the debug server options are used
-	// Otherwise the run options are used
-	let serverOptions: ServerOptions = {
+	// Server uses 'run' options in normal mode, 'debug' options in debug mode
+	const serverOptions: ServerOptions = {
 		run: { module: serverModule, transport: TransportKind.ipc },
 		debug: { module: serverModule, transport: TransportKind.ipc, options: debugOptions }
 	}
 
-	// Options to control the language client
-	let clientOptions: LanguageClientOptions = {
+	const clientOptions: LanguageClientOptions = {
 		// Register the server for ejs files
 		documentSelector: [{ language: 'ejs', scheme: 'file' }],
 		synchronize: {
 			// Synchronize the setting section 'ejs-support' to the server
 			configurationSection: 'ejs-support',
 			// Notify the server about file changes to '.clientrc' files contain in the workspace
+			// TODO: find out if this is useful at all
 			fileEvents: workspace.createFileSystemWatcher('**/.clientrc')
 		}
 	}
 
 	// Create the language client and start the client.
-	let disposable = new LanguageClient('ejs-support-client', 'EJS language support extension',
-		serverOptions, clientOptions).start();
+	const disposable =
+		new LanguageClient('ejs-support-client', 'EJS language support extension', serverOptions, clientOptions)
+			.start();
 
 	// Push the disposable to the context's subscriptions so that the 
-	// client can be deactivated on extension deactivation
+	// client will be deactivated on extension deactivation
 	context.subscriptions.push(disposable);
+
+	// TEMP, for debugging
+	const disposable2 = commands.registerCommand('extension.sayHello', () => {
+		// Display a message box to the user
+		window.showInformationMessage('Hello World!');
+	});
+
+	context.subscriptions.push(disposable2);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,0 +1,46 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) DigitalBrainstem
+ * Licensed under the MIT License. See LICENSE in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+'use strict';
+
+import * as path from 'path';
+
+import { workspace, ExtensionContext } from 'vscode';
+import { LanguageClient, LanguageClientOptions, ServerOptions, TransportKind } from 'vscode-languageclient';
+
+export function activate(context: ExtensionContext) {
+
+	// The server is implemented in node
+	let serverModule = context.asAbsolutePath(path.join('out', 'src', 'server.js'));
+
+	// The debug options for the server
+	let debugOptions = { execArgv: ["--nolazy", "--inspect=6009"] };
+
+	// If the extension is launched in debug mode then the debug server options are used
+	// Otherwise the run options are used
+	let serverOptions: ServerOptions = {
+		run: { module: serverModule, transport: TransportKind.ipc },
+		debug: { module: serverModule, transport: TransportKind.ipc, options: debugOptions }
+	}
+
+	// Options to control the language client
+	let clientOptions: LanguageClientOptions = {
+		// Register the server for ejs files
+		documentSelector: [{ language: 'ejs', scheme: 'file' }],
+		synchronize: {
+			// Synchronize the setting section 'ejs-support' to the server
+			configurationSection: 'ejs-support',
+			// Notify the server about file changes to '.clientrc' files contain in the workspace
+			fileEvents: workspace.createFileSystemWatcher('**/.clientrc')
+		}
+	}
+
+	// Create the language client and start the client.
+	let disposable = new LanguageClient('ejs-support-client', 'EJS language support extension',
+		serverOptions, clientOptions).start();
+
+	// Push the disposable to the context's subscriptions so that the 
+	// client can be deactivated on extension deactivation
+	context.subscriptions.push(disposable);
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,182 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) DigitalBrainstem
+ * Licensed under the MIT License. See LICENSE in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+'use strict';
+
+import {
+	IPCMessageReader, IPCMessageWriter, createConnection, IConnection, TextDocuments, TextDocument,
+	Diagnostic, DiagnosticSeverity, InitializeResult, TextDocumentPositionParams, CompletionItem,
+	CompletionItemKind
+} from 'vscode-languageserver';
+
+// Create a connection for the server. The connection uses Node's IPC as a transport
+let connection: IConnection = createConnection(new IPCMessageReader(process), new IPCMessageWriter(process));
+
+// Create a simple text document manager. The text document manager supports full document sync only
+let documents: TextDocuments = new TextDocuments();
+
+// Make the text document manager listen on the connection for open, change and close text document events
+documents.listen(connection);
+
+let shouldSendDiagnosticRelatedInformation: boolean = false;
+
+// After the server has started the client sends an initialize request. The server receives
+// in the passed params the rootPath of the workspace plus the client capabilities.
+connection.onInitialize((_params): InitializeResult => {
+	shouldSendDiagnosticRelatedInformation = _params.capabilities &&
+		_params.capabilities.textDocument &&
+		_params.capabilities.textDocument.publishDiagnostics &&
+		_params.capabilities.textDocument.publishDiagnostics.relatedInformation;
+
+	return {
+		capabilities: {
+			// Tell the client that the server works in FULL text document sync mode
+			textDocumentSync: documents.syncKind,
+			// Tell the client that the server support code complete
+			completionProvider: { resolveProvider: true }
+		}
+	}
+});
+
+// The content of a text document has changed. This event is emitted
+// when the text document first opened or when its content has changed.
+documents.onDidChangeContent((change) => {
+	validateTextDocument(change.document);
+});
+
+// The settings interface describe the server relevant settings part
+interface Settings {
+	"ejs-support": EjsSettings;
+}
+
+// These are the example settings we defined in the client's package.json
+// file
+interface EjsSettings {
+	maxNumberOfProblems: number;
+}
+
+// hold the maxNumberOfProblems setting
+let maxNumberOfProblems: number;
+
+// The settings have changed. Is send on server activation as well.
+connection.onDidChangeConfiguration((change) => {
+	let settings = <Settings>change.settings;
+	maxNumberOfProblems = settings['ejs-support'].maxNumberOfProblems || 100;
+	// Revalidate any open text documents
+	documents.all().forEach(validateTextDocument);
+});
+
+/**
+ * This example function finds appearances of 'typescript' and suggests that
+ * it should be spelled 'TypeScript'.
+ * @param textDocument document to validate
+ */
+function validateTextDocument(textDocument: TextDocument): void {
+	let diagnostics: Diagnostic[] = [];
+	let lines = textDocument.getText().split(/\r?\n/g);
+	let problems = 0;
+	for (let i = 0; i < lines.length && problems < maxNumberOfProblems; i++) {
+		let line = lines[i];
+		let index = line.toLocaleLowerCase().indexOf('typescript');
+		if (index >= 0) {
+			problems++;
+
+			let diagnostic: Diagnostic = {
+				severity: DiagnosticSeverity.Warning,
+				range: {
+					start: { line: i, character: index },
+					end: { line: i, character: index + 10 }
+				},
+				message: `${line.substr(index, 10)} should be spelled TypeScript`,
+				source: 'EJS language support'
+			};
+			if (shouldSendDiagnosticRelatedInformation) {
+				diagnostic.relatedInformation = [
+					{
+						location: {
+							uri: textDocument.uri,
+							range: {
+								start: { line: i, character: index },
+								end: { line: i, character: index + 10 }
+							}
+						},
+						message: 'Spelling matters'
+					},
+					{
+						location: {
+							uri: textDocument.uri,
+							range: {
+								start: { line: i, character: index },
+								end: { line: i, character: index + 10 }
+							}
+						},
+						message: 'Particularly for names'
+					}
+				];
+			}
+			diagnostics.push(diagnostic);
+		}
+	}
+	// Send the computed diagnostics to VSCode.
+	connection.sendDiagnostics({ uri: textDocument.uri, diagnostics });
+}
+
+connection.onDidChangeWatchedFiles((_change) => {
+	// Monitored files have change in VSCode
+	connection.console.log('We received a file change event');
+});
+
+
+// This handler provides the initial list of the completion items.
+connection.onCompletion((_textDocumentPosition: TextDocumentPositionParams): CompletionItem[] => {
+	// The pass parameter contains the position of the text document in
+	// which code complete got requested. For the example we ignore this
+	// info and always provide the same completion items.
+	return [
+		{
+			label: 'TypeScript',
+			kind: CompletionItemKind.Text,
+			data: 1
+		},
+		{
+			label: 'JavaScript',
+			kind: CompletionItemKind.Text,
+			data: 2
+		}
+	]
+});
+
+// This handler resolve additional information for the item selected in
+// the completion list.
+connection.onCompletionResolve((item: CompletionItem): CompletionItem => {
+	if (item.data === 1) {
+		item.detail = 'TypeScript details';
+		item.documentation = 'TypeScript documentation';
+	} else if (item.data === 2) {
+		item.detail = 'JavaScript details';
+		item.documentation = 'JavaScript documentation';
+	}
+	return item;
+});
+
+connection.onDidOpenTextDocument((params) => {
+	// A text document got opened in VSCode.
+	// params.uri uniquely identifies the document. For documents store on disk this is a file URI.
+	// params.text the initial full content of the document.
+	connection.console.log(`${params.textDocument.uri} opened.`);
+});
+connection.onDidChangeTextDocument((params) => {
+	// The content of a text document did change in VSCode.
+	// params.uri uniquely identifies the document.
+	// params.contentChanges describe the content changes to the document.
+	connection.console.log(`${params.textDocument.uri} changed: ${JSON.stringify(params.contentChanges)}`);
+});
+connection.onDidCloseTextDocument((params) => {
+	// A text document got closed in VSCode.
+	// params.uri uniquely identifies the document.
+	connection.console.log(`${params.textDocument.uri} closed.`);
+});
+
+// Listen on the connection
+connection.listen();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,19 @@
+{
+	"compilerOptions": {
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"noImplicitAny": true,
+		"noImplicitReturns": true,		
+		"target": "es6",
+		"module": "commonjs",
+		"moduleResolution": "node",
+		"rootDir": ".",
+		"outDir": "out",
+		"lib": [ "es2016" ],
+		"sourceMap": true
+	},
+	"exclude": [
+		"node_modules",
+		"server"
+	]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
 		"noUnusedLocals": true,
 		"noUnusedParameters": true,
 		"noImplicitAny": true,
-		"noImplicitReturns": true,		
+		"noImplicitReturns": true,
 		"target": "es6",
 		"module": "commonjs",
 		"moduleResolution": "node",


### PR DESCRIPTION
### Work in progress
## About
I added the language server implementation. This started out as a copy from the official [language server example](https://github.com/Microsoft/vscode-extension-samples/tree/master/lsp-sample). The extension now includes:
- Debugging support. You can connect to the language server via the `Attach to client` launch config;
- TypeScript source files that are activated via the `"activationEvents": [ "onLanguage:ejs" ]` event. (And compile into javascript, see below);
- The language server requires a much newer version of the vs code API: I used v1.18.x, but lower may be possible (for compatibility with older clients);
- Two configuration settings that are used by the server, and a command ('hello world',  which does exactly what you think it does).

The server currently continuously checks the file for occurences of `typescript` and if it found any, issues a warning with the suggestion that it should be changed to `TypeScript`. (This is still from the example.)

## Setup
Because the language server has some dependencies and TypeScript is a compiled language (devDependency), you'll need install these:
```bash
$ npm install
```
Whenever you make changes, you need to compile the extension `.ts` files. I'm told there is a way to do this automatically, but I haven't found it yet. (This happens before the extension is published, too.)
```bash
$ npm run vscode:prepublish
```

## Conclusion
This sets the basis for things like **formatting**, code analysis, and more! We could also include for example a setting for the delimiter that automatically replaces the default delimiter in the `.tmLanguage` or `ejs.json` language grammer file!

Note: copy of #15 (this is into `dev` instead of `master`).