### PR TITLE
fix: Terminate single‑line JS comments at EJS closing tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # CHANGE LOG #
 
+## master ##
+
+Fixed single-line JS comments not being terminated correctly by an EJS closing tag. ([#28](https://github.com/Digitalbrainstem/ejs-grammar/issues/28))
+
 ## 0.4.4 ##
 
-Puiblished Untested Code. Rolling back.
+Published Untested Code. Rolling back.
 
 ## 0.4.1 ##
 
@@ -44,7 +48,7 @@ Update ReadMe
 
 ## 0.2.0 ##
 
-+ Feature: Allows support for alternate tags of EJS `<??>` now work. 
++ Feature: Allows support for alternate tags of EJS `<??>` now work.
 + Adding Changelog.
 
 *Note: Technically, `<?%>` OR `<%?>` works with this version. I need to comb through the code and make sure only matching pairs work. That is an item for down the road though.*

--- a/syntaxes/ejs.json
+++ b/syntaxes/ejs.json
@@ -80,25 +80,34 @@
 	],
 	"repository": {
 		"tag-comment": {
-			"begin": "<(%|\\?)#",
-			"end": "(%|\\?)>",
+			"begin": "<[%?]#",
+			"end": "[%?]>",
 			"name": "comment.block.ejs"
 		},
 		"tag-ejs": {
-			"begin": "<(%|\\?)(?!%)[_=-]?",
+			"begin": "<[%?][_=-]?",
 			"beginCaptures": {
 				"0": {
 					"name": "punctuation.definition.tag.begin.ejs"
 				}
 			},
-			"end": "[_-]?(%|\\?)>",
+			"end": "[_-]?[%?]>",
 			"endCaptures": {
 				"0": {
 					"name": "punctuation.definition.tag.end.ejs"
 				}
 			},
-			"contentName": "source.js",
 			"patterns": [
+				{
+					"begin": "//",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.definition.comment.js"
+						}
+					},
+					"end": "(?=[_-]?[%?]>)|\\n",
+					"name": "comment.line.double-slash.js"
+				},
 				{
 					"include": "source.js"
 				}


### PR DESCRIPTION
Fixes&nbsp;#28

---

Note that:
```ejs
Stuff
<%/*%>
Hidden
<%*/%>
Visible
```
results&nbsp;in:
```html
Stuff

Visible
```
