### PR TITLE
fix: Disable EJS inside HTML embedded blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master ##
 
 Fixed single-line JS comments not being terminated correctly by an EJS closing tag. ([#28](https://github.com/Digitalbrainstem/ejs-grammar/issues/28))
+Fixed broken EJS inside HTML `<script>` and `<style>` elements ([#27](https://github.com/Digitalbrainstem/ejs-grammar/issues/27) and [#31](https://github.com/Digitalbrainstem/ejs-grammar/issues/31))
 
 ## 0.4.4 ##
 

--- a/syntaxes/ejs.json
+++ b/syntaxes/ejs.json
@@ -12,7 +12,7 @@
 				}
 			]
 		},
-		"L:meta.block.js - (comment.block, text.html.ejs.override-js)": {
+		"L:(* - meta.embedded.block.html) meta.block.js - (comment.block, text.html.ejs.override-js)": {
 			"patterns": [
 				{
 					"begin": "[_-]?(%|\\?)>",
@@ -97,6 +97,7 @@
 					"name": "punctuation.definition.tag.end.ejs"
 				}
 			},
+			"contentName": "source.js",
 			"patterns": [
 				{
 					"begin": "//",


### PR DESCRIPTION
- Fixes #31
- Fixes #27

This works by disabling EJS inside HTML embedded blocks (`<script>` and `<style>`), which has weird behaviour.