### PR TITLE
fix: Use `embeddedLanguages` to use correct language configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 Fixed single-line JS comments not being terminated correctly by an EJS closing tag. ([#28](https://github.com/Digitalbrainstem/ejs-grammar/issues/28))
 Fixed broken EJS inside HTML `<script>` and `<style>` elements. ([#27](https://github.com/Digitalbrainstem/ejs-grammar/issues/27) and [#31](https://github.com/Digitalbrainstem/ejs-grammar/issues/31))
 Fixed surrounding a selection with JavaScript template literals.
+Fixed incorrect comments in HTML and JavaScript portions. ([#22](https://github.com/Digitalbrainstem/ejs-grammar/issues/22))
 
 ## 0.4.4 ##
 

--- a/language-configuration.json
+++ b/language-configuration.json
@@ -2,7 +2,6 @@
 	"comments": {
 		// symbols used for start and end of a block comment.
 		"blockComment": [ "<%#", "%>" ],
-		"lineComment": "//", // "#"
 	},
 
 	// symbols used as brackets
@@ -19,11 +18,8 @@
 		{ "open": "{", "close": "}" },
 		{ "open": "[", "close": "]" },
 		{ "open": "(", "close": ")" },
-		{ "open": "'", "close": "'", "notIn": ["string", "comment"] },
-		{ "open": "\"", "close": "\"", "notIn": ["string"] },
-		{ "open": "`", "close": "`", "notIn": ["string", "comment"] },
-		{ "open": "/*", "close": " */", "notIn": ["string"] },
-		{ "open": "/**", "close": " */", "notIn": ["string"] },
+		{ "open": "'", "close": "'" },
+		{ "open": "\"", "close": "\"" },
 		{ "open": "<!--", "close": "-->", "notIn": [ "comment", "string" ]},
 		{ "open": "<%", "close": "%>" },
 	],
@@ -36,18 +32,12 @@
 		["(", ")"],
 		["'", "'"],
 		["\"", "\""],
-		["`", "`"],
 	],
-
-	"indentationRules": {
-		"increaseIndentPattern": "(\\(|\\[|((else(\\s)?)?if|else|for(each)?|while|switch).*:)\\s*(/[/*].*)?$",
-		"decreaseIndentPattern": "^(.*\\*\\/)?\\s*((\\})|(\\)+[;,])|(\\][;,])|\\b(else:)|\\b((end(if|for(each)?|while|switch));))"
-	},
 
 	"folding": {
 		"markers": {
-			"start": "^\\s*(?:(?:#|\/\/)region\\b|<!--\\s*#region\\b.*-->)",
-			"end": "^\\s*(?:(?:#|\/\/)endregion\\b|<!--\\s*#endregion\\b.*-->)",
+			"start": "^\\s*(?:<%#(?:\\s*#)?region\\b.*%>|<!--\\s*#region\\b.*-->)",
+			"end": "^\\s*(?:<%#(?:\\s*#)?endregion\\b.*%>|<!--\\s*#endregion\\b.*-->)",
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
 				"scopeName": "text.html.ejs",
 				"path": "./syntaxes/ejs.json",
 				"embeddedLanguages": {
-					"section.embedded.source.ejs": "ejs"
+					"source.css": "css",
+					"source.js": "javascript"
 				}
 			}
 		]


### PR DESCRIPTION
Fixes #22

Note that I can’t put `"text.html": "html"` into the `embeddedLanguages` block, because that would break EJS comments, `<%` tag auto closing and `<%#region%>` folding.

---

review?(@Betanu701)