### PR TITLE
feat: Add EJS support to Markdown [WIP]

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,17 @@
 					"meta.embedded.block.ejs": "ejs",
 					"meta.embedded.block.javascript": "source.js"
 				}
+			},
+			{
+				"scopeName": "text.html.markdown.ejs",
+				"path": "./syntaxes/markdown-ejs.tmLanguage.json",
+				"injectTo": [
+					"text.html.markdown"
+				],
+				"embeddedLanguages": {
+					"meta.embedded.block.ejs": "ejs",
+					"meta.embedded.block.javascript": "source.js"
+				}
 			}
 		],
 		"configurationDefaults": {

--- a/syntaxes/markdown-ejs.tmLanguage.json
+++ b/syntaxes/markdown-ejs.tmLanguage.json
@@ -1,0 +1,44 @@
+{
+	"scopeName": "text.html.markdown.ejs",
+	"injectionSelector": "L:(text.html.markdown markup.fenced_code.block.markdown)",
+	"patterns": [
+		{
+			"include": "#fenced_code_block_ejs"
+		}
+	],
+	"repository": {
+		"fenced_code_block_ejs": {
+			"begin": "(^|\\G)(\\s*)(`{3,}|~{3,})\\s*(?i:(ejs)(\\s+[^`~]*)?$)",
+			"name": "markup.fenced_code.block.markdown",
+			"end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
+			"beginCaptures": {
+				"3": {
+					"name": "punctuation.definition.markdown"
+				},
+				"5": {
+					"name": "fenced_code.block.language"
+				},
+				"6": {
+					"name": "fenced_code.block.language.attributes"
+				}
+			},
+			"endCaptures": {
+				"3": {
+					"name": "punctuation.definition.markdown"
+				}
+			},
+			"patterns": [
+				{
+					"begin": "(^|\\G)(\\s*)(.*)",
+					"while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+					"contentName": "meta.embedded.block.ejs",
+					"patterns": [
+						{
+							"include": "text.html.ejs"
+						}
+					]
+				}
+			]
+		}
+	}
+}


### PR DESCRIPTION
Note that this currently only highlights **EJS** tags and not **HTML** tags:
![Screenshot_2019-10-20 – VS Code EJS Support – No HTML Tags](https://user-images.githubusercontent.com/3889017/67159129-ef508980-f340-11e9-8668-366c57e337e7.png)

It also doesn’t close correctly when a callback function has **HTML** inside it:
![Screenshot_2019-10-20 – VS Code EJS Support – Broken JavaScript Function](https://user-images.githubusercontent.com/3889017/67159136-0db68500-f341-11e9-9fae-f27e8152da68.png)
