### PR TITLE
fix: snippet tabbing, duplicates, and accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,20 +32,20 @@ If there is anything that I missed or features you would like this to include. [
 
 → Denotes the `TAB` key.
 
-| Snippet→   | Alternate  | Output                                                                                                  |
-| ---------- | --------   | ------------------------------------------------------------------------------------------------------- |
-| `ejs→`     | `<%`       | `<% %>` - No output tag                                                                                 |
-| `ejsout→`  | `<%=`      | `<%= %>` - Outputs HTML value                                                                           |
-| `ejsesc→`  | `<%-`      | `<%- %>` - Outputs unescaped                                                                            |
-| `ejscom→`  | `<%#`      | `<%# %>` - Comment tag                                                                                  |
-| `ejslit→`  | `<%%`      | `<%% %>` - Outputs Literal <%                                                                           |
-| `ejsinc→`  | `<%`       | `include` statement                                                                                       |
-| `ejsfor→`  | `<%`       | `for` Javascript Loop                                                                                             |
-| `ejseach→` | `<%`       | `forEach` Javascript Loop                                                                                     |
-| `ejsof→`   | `<%`       | `for...of` JavaScript Loop                                                                              |
-| `ejsif→`   | `<%`       | `if` Statement with condition                                                                                     |
-| `ejselif→` | `<%`       | `else if` Statement - *Middle section only.* Assumes you have already written the first `if` statement. |
-| `ejselse→` | `<%`       | `else` Statement - *Middle section only.* Assumes you have already written the first `if` statement.    |
+| Snippet    | Alternate | Output                                                   |
+| ---------- | --------- | -------------------------------------------------------- |
+| `ejs→`     | `<%`      | `<% %>` – No output tag                                  |
+| `ejsesc→`  | `<%=`     | `<%= %>` – Output **escaped** value                      |
+| `ejsraw→`  | `<%-`     | `<%- %>` – Output **raw/unescaped** value (injects HTML) |
+| `ejscom→`  | `<%#`     | `<%# %>` – Comment, no output                            |
+| `ejslit→`  | `<%%`     | `<%% %>` – Output literal `<%`                           |
+| `ejsinc→`  | `<%`      | `<%- include() %>` – Include another file                |
+| `ejsfor→`  | `<%`      | `for` loop – Index-based                                 |
+| `ejsof→`   | `<%`      | `for...of` loop – Iterable-based                         |
+| `ejseach→` | `<%`      | `.forEach()` loop – Array iteration                      |
+| `ejsif→`   | `<%`      | `if` statement                                           |
+| `ejselif→` | `<%`      | `else if` statement _Middle section only_                |
+| `ejselse→` | `<%`      | `else` statement                                         |
 
 ## EJS docs ##
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ If there is anything that I missed or features you would like this to include. [
 | `ejsinc→`  | `<%`       | `include` statement                                                                                       |
 | `ejsfor→`  | `<%`       | `for` Javascript Loop                                                                                             |
 | `ejseach→` | `<%`       | `forEach` Javascript Loop                                                                                     |
+| `ejsof→`   | `<%`       | `for...of` JavaScript Loop                                                                              |
 | `ejsif→`   | `<%`       | `if` Statement with condition                                                                                     |
 | `ejselif→` | `<%`       | `else if` Statement - *Middle section only.* Assumes you have already written the first `if` statement. |
 | `ejselse→` | `<%`       | `else` Statement - *Middle section only.* Assumes you have already written the first `if` statement.    |

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -79,7 +79,7 @@
   "EJS Else If Statement": {
     "prefix": "ejselif",
     "body": [
-      "<% } else if ({$1:condition}) { %>",
+      "<% } else if (${1:condition}) { %>",
       " $2"
     ],
     "description": "EJS if statement"

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -1,181 +1,134 @@
 {
   "EJS No Output": {
-    "prefix": "ejs",
-    "body": [
-      "<% $1 %>$2"
+    "prefix": [
+      "ejs",
+      "<%"
     ],
-    "description": "EJS No Output"
-  },
-  "EJS Output Value": {
-    "prefix": "ejsout",
     "body": [
-      "<%= $1 %>$2"
+      "<% $1 %>$0"
     ],
-    "description": "EJS outputs no value"
+    "description": "EJS No Output (Run JS)"
   },
   "EJS Output Escaped": {
-    "prefix": "ejsesc",
-    "body": [
-      "<%- $1 %>$2"
+    "prefix": [
+      "ejsesc",
+      "<%="
     ],
-    "description": "EJS outputs value"
+    "body": [
+      "<%= $1 %>$0"
+    ],
+    "description": "EJS outputs escaped value"
+  },
+  "EJS Output Unescaped": {
+    "prefix": [
+      "ejsunesc",
+      "ejsraw",
+      "<%-"
+    ],
+    "body": [
+      "<%- $1 %>$0"
+    ],
+    "description": "EJS outputs value raw and unescaped"
   },
   "EJS Comment": {
-    "prefix": "ejscom",
-    "body": [
-      "<%# $1 %>$2"
+    "prefix": [
+      "ejscom",
+      "<%#"
     ],
-    "description": "EJS comment tag with no output"
+    "body": [
+      "<%# $1 %>$0"
+    ],
+    "description": "EJS comment with no output"
   },
   "EJS Literal": {
-    "prefix": "ejslit",
+    "prefix": [
+      "ejslit",
+      "<%%"
+    ],
     "body": [
-      "<%% $1 %>$2"
+      "<%% $1 %>$0"
     ],
     "description": "EJS outputs a literal '<%'"
   },
   "EJS Include": {
-    "prefix": "ejsinc",
+    "prefix": [
+      "ejsinc",
+      "<%"
+    ],
     "body": [
-      "<%- include('$1') %>$2"
+      "<%- include('$1') %>$0"
     ],
     "description": "EJS include statement"
   },
   "EJS For Loop": {
-    "prefix": "ejsfor",
+    "prefix": [
+      "ejsfor",
+      "<%"
+    ],
     "body": [
-      "<% for( let ${1:index} = 0; ${1:index} < ${2:array}.length; ${1:index}++ ) { %>",
-      "$3",
+      "<% for( let ${1:index} = 0; ${1:index} < ${2:number}; ${1:index}++ ) { %>",
+      "\t$0",
       "<% } %>"
     ],
     "description": "EJS For Loop"
   },
-  "EJS ForEach": {
-    "prefix": "ejseach",
+  "EJS For...Of Loop": {
+    "prefix": [
+      "ejsof",
+      "<%"
+    ],
     "body": [
-      "<% ${1:array}.forEach(${2:element} => { %>",
-      " $3",
+      "<% for (${1|const,let|} ${2:variable} of ${3:iterable}) { %>",
+      "\t$0",
+      "<% } %>"
+    ],
+    "description": "EJS For...Of Loop"
+  },
+  "EJS ForEach": {
+    "prefix": [
+      "ejseach",
+      "<%"
+    ],
+    "body": [
+      "<% ${1:array}.forEach((${2:element}) => { %>",
+      "\t$0",
       "<% }) %>"
     ],
     "description": "EJS ForEach Loop"
   },
   "EJS If Statement": {
-    "prefix": "ejsif",
+    "prefix": [
+      "ejsif",
+      "<%"
+    ],
     "body": [
       "<% if (${1:condition}) { %>",
-      " $2",
+      "\t$0",
       "<% } %>"
-    ],
-    "description": "EJS if statement"
-  },
-  "EJS Else Statement": {
-    "prefix": "ejselse",
-    "body": [
-      "<% } else { %>",
-      " $1"
     ],
     "description": "EJS if statement"
   },
   "EJS Else If Statement": {
-    "prefix": "ejselif",
+    "prefix": [
+      "ejselif",
+      "<%"
+    ],
     "body": [
       "<% } else if (${1:condition}) { %>",
-      " $2"
+      "\t$0"
     ],
-    "description": "EJS if statement"
+    "description": "EJS else if statement"
   },
-  "EJS TAG": {
-    "prefix": "<%",
-    "body": [
-      "<% $1 %>$2"
+  "EJS Else Statement": {
+    "prefix": [
+      "ejselse",
+      "<%"
     ],
-    "description": "EJS No Output"
-  },
-  "EJS TAG Output Value": {
-    "prefix": "<%=",
-    "body": [
-      "<%= $1 %>$2"
-    ],
-    "description": "EJS outputs no value"
-  },
-  "EJS TAG Output Escaped": {
-    "prefix": "<%-",
-    "body": [
-      "<%- $1 %>$2"
-    ],
-    "description": "EJS outputs value"
-  },
-  "EJS TAG Comment": {
-    "prefix": "<%#",
-    "body": [
-      "<%# $1 %>$2"
-    ],
-    "description": "EJS comment tag with no output"
-  },
-  "EJS TAG Literal": {
-    "prefix": "<%%",
-    "body": [
-      "<%% $1 %>$2"
-    ],
-    "description": "EJS outputs a literal '<%'"
-  },
-  "EJS TAG Include": {
-    "prefix": "<% ",
-    "body": [
-      "<%- include('$1') %>$2"
-    ],
-    "description": "EJS include statement"
-  },
-  "EJS TAG For Loop": {
-    "prefix": "<% ",
-    "body": [
-      "<% for( let ${1:index} = 0; ${1:index} < ${2:array}.length; ${1:index}++ ) { %>",
-      "$3",
-      "<% } %>"
-    ],
-    "description": "EJS For Loop"
-  },
-  "EJS TAG ForEach": {
-    "prefix": "<% ",
-    "body": [
-      "<% ${1:array}.forEach(${2:element} => { %>",
-      " $3",
-      "<% }) %>"
-    ],
-    "description": "EJS ForEach Loop"
-  },
-  "EJS TAG If Statement": {
-    "prefix": "<% ",
-    "body": [
-      "<% if (${1:condition}) { %>",
-      " $2",
-      "<% } %>"
-    ],
-    "description": "EJS if statement"
-  },
-  "EJS TAG Else Statement": {
-    "prefix": "<% ",
     "body": [
       "<% } else { %>",
-      " $1"
-    ],
-    "description": "EJS if statement"
-  },
-  "EJS TAG Else If Statement": {
-    "prefix": "<% ",
-    "body": [
-      "<% } else if ({$1:condition}) { %>",
-      " $2"
-    ],
-    "description": "EJS if statement"
-  },
-  "EJS For...Of Loop": {
-    "prefix": ["ejsof", "<%"],
-    "body": [
-      "<% for (const ${1:variable} of ${2:iterable}) { %>", 
-      "  $3",
+      "\t$0",
       "<% } %>"
     ],
-    "description": "EJS For...Of Loop"
+    "description": "EJS else statement"
   }
 }

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -168,5 +168,14 @@
       " $2"
     ],
     "description": "EJS if statement"
+  },
+  "EJS For...Of Loop": {
+    "prefix": ["ejsof", "<%"],
+    "body": [
+      "<% for (const ${1:variable} of ${2:iterable}) { %>", 
+      "  $3",
+      "<% } %>"
+    ],
+    "description": "EJS For...Of Loop"
   }
 }


### PR DESCRIPTION
Fixes #105 and #87 

**Changes**
- Merged duplicate snippets into the same, having multiple prefixes.
- Fixed '<%-' and '<%=' snippets having confusing descriptions
- Spaces -> tabs for code-block creating snippets (ie 'if')
- Added closing '}' to else statement, as you would never not need it.
- Added snippet choice insertion feature to choose 'let' or 'const' in for..of loop.

Because I completely redid the file, I merged a couple related PR's before I made my changes: PR [58](https://github.com/Digitalbrainstem/ejs-grammar/pull/58) & [100](https://github.com/Digitalbrainstem/ejs-grammar/pull/100)